### PR TITLE
Changed to EqualsExact for structural equality

### DIFF
--- a/NHibernate.Spatial/Type/GeometryTypeBase.cs
+++ b/NHibernate.Spatial/Type/GeometryTypeBase.cs
@@ -219,7 +219,7 @@ namespace NHibernate.Spatial.Type
             {
                 try
                 {
-                    return ga.SRID == gb.SRID && ga.Equals(gb);
+                    return ga.SRID == gb.SRID && ga.EqualsExact(gb);
                 }
                 catch (TopologyException)
                 {


### PR DESCRIPTION
This is initially a problem in the NetTopologySuite but I think this workaround may also be a more correct solution in general.

The current way does a topological equality which should be a less strict than the structural one, i.e when a structural comparison is true the topological one should also always be true. Tho my test cases shows this is not always the case where my objects always ends up as dirty, while changing to structural comparison makes them equal. Anyway I think the structural comparison should be the most correct way to do it in this case and as a bonus should also be faster than the topological one. 