### PR TITLE
Add support for PostGIS 2.x spatial functions

### DIFF
--- a/NHibernate.Spatial.PostGis/Dialect/PostGis20Dialect.cs
+++ b/NHibernate.Spatial.PostGis/Dialect/PostGis20Dialect.cs
@@ -1,0 +1,86 @@
+﻿// Copyright 2007 - Ricardo Stuven (rstuven@gmail.com)
+//
+// This file is part of NHibernate.Spatial.
+// NHibernate.Spatial is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// NHibernate.Spatial is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public License
+// along with NHibernate.Spatial; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+using NHibernate.SqlCommand;
+using NHibernate.Type;
+using System;
+
+namespace NHibernate.Spatial.Dialect
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class PostGis20Dialect : PostGisDialect
+    {
+        protected override void RegisterSpatialFunction(string name, IType returnedType, int allowedArgsCount)
+        {
+            RegisterSpatialFunction(name, SpatialDialect.IsoPrefix + name, returnedType, allowedArgsCount);
+        }
+
+        protected override void RegisterSpatialFunction(string name, IType returnedType)
+        {
+            RegisterSpatialFunction(name, SpatialDialect.IsoPrefix + name, returnedType);
+        }
+
+        /// <summary>
+        /// Gets the spatial aggregate string.
+        /// </summary>
+        /// <param name="geometry">The geometry.</param>
+        /// <param name="aggregate">The aggregate.</param>
+        /// <returns></returns>
+        public override SqlString GetSpatialAggregateString(object geometry, SpatialAggregate aggregate)
+        {
+            string aggregateFunction;
+            switch (aggregate)
+            {
+                case SpatialAggregate.Collect:
+                    aggregateFunction = SpatialDialect.IsoPrefix + "Collect";
+                    break;
+                case SpatialAggregate.ConvexHull:
+                    aggregateFunction = SpatialDialect.IsoPrefix + "ConvexHull";
+                    break;
+                case SpatialAggregate.Envelope:
+                    aggregateFunction = SpatialDialect.IsoPrefix + "Extent";
+                    break;
+                case SpatialAggregate.Intersection:
+                    aggregateFunction = IntersectionAggregateName;
+                    break;
+                case SpatialAggregate.Union:
+                    aggregateFunction = SpatialDialect.IsoPrefix + "Union";
+                    break;
+                default:
+                    throw new ArgumentException("Invalid spatial aggregate argument");
+            }
+            return new SqlStringBuilder()
+                .Add(aggregateFunction)
+                .Add("(")
+                .AddObject(geometry)
+                .Add(")")
+                .ToSqlString();
+        }
+
+        /// <summary>
+        /// Gets the spatial create string.
+        /// </summary>
+        /// <param name="schema">The schema.</param>
+        /// <returns></returns>
+        public override string GetSpatialCreateString(string schema)
+        {
+            return GetSpatialCreateString(schema, SpatialDialect.IsoPrefix);
+        }
+    }
+}

--- a/NHibernate.Spatial.PostGis/Metadata/GeometryColumn.PostGis20Dialect.hbm.xml
+++ b/NHibernate.Spatial.PostGis/Metadata/GeometryColumn.PostGis20Dialect.hbm.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2">
+
+	<class name="NHibernate.Spatial.Metadata.GeometryColumn, NHibernate.Spatial"
+		schema="public"
+		table="GEOMETRY_COLUMNS"
+		lazy="false"
+		mutable="false">
+		<composite-id>
+			<key-property name="TableCatalog"	column="F_TABLE_CATALOG" />
+			<key-property name="TableSchema"	column="F_TABLE_SCHEMA" />
+			<key-property name="TableName"		column="F_TABLE_NAME" />
+			<key-property name="Name"			column="F_GEOMETRY_COLUMN" />
+		</composite-id>
+		<property name="SRID"					column="SRID" />
+		<property name="Subtype"				column="TYPE" />
+		<property name="Dimension"				column="COORD_DIMENSION" />
+	</class>
+</hibernate-mapping>

--- a/NHibernate.Spatial.PostGis/Metadata/SpatialReferenceSystem.PostGis20Dialect.hbm.xml
+++ b/NHibernate.Spatial.PostGis/Metadata/SpatialReferenceSystem.PostGis20Dialect.hbm.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2">
+
+	<class name="NHibernate.Spatial.Metadata.SpatialReferenceSystem, NHibernate.Spatial"
+		schema="public"
+		table="SPATIAL_REF_SYS"
+		lazy="false"
+		mutable="true">
+		<id name="SRID" column="SRID" type="Int32">
+			<generator class="assigned" />
+		</id>
+		<property name="AuthorityName"	column="AUTH_NAME"	type="String" />
+		<property name="AuthoritySRID"	column="AUTH_SRID"  type="Int32" />
+		<property name="WellKnownText"	column="SRTEXT"		type="String" />
+	</class>
+</hibernate-mapping>

--- a/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
+++ b/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
@@ -84,6 +84,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Dialect\PostGis20Dialect.cs" />
     <Compile Include="Dialect\PostGisDialect.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Type\PostGisGeometryType.cs" />
@@ -100,6 +101,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Metadata\GeometryColumn.PostGis20Dialect.hbm.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Metadata\SpatialReferenceSystem.PostGis20Dialect.hbm.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Tests.NHibernate.Spatial.PostGis/PostGisSpatialQueriesFixture.cs
+++ b/Tests.NHibernate.Spatial.PostGis/PostGisSpatialQueriesFixture.cs
@@ -17,7 +17,7 @@ namespace Tests.NHibernate.Spatial.RandomGeometries
             return string.Format(@"
 SELECT count(*)
 FROM linestringtest
-WHERE the_geom && GeomFromText('{0}', 4326)
+WHERE the_geom && ST_GeomFromText('{0}', 4326)
 ", filterString);
         }
 
@@ -26,7 +26,7 @@ WHERE the_geom && GeomFromText('{0}', 4326)
             return string.Format(@"
 SELECT count(*)
 FROM polygontest
-WHERE the_geom && GeomFromText('{0}', 4326)
+WHERE the_geom && ST_GeomFromText('{0}', 4326)
 ", filterString);
         }
 
@@ -35,7 +35,7 @@ WHERE the_geom && GeomFromText('{0}', 4326)
             return string.Format(@"
 SELECT count(*)
 FROM multilinestringtest
-WHERE the_geom && GeomFromText('{0}', 4326)
+WHERE the_geom && ST_GeomFromText('{0}', 4326)
 ", filterString);
         }
 
@@ -45,7 +45,7 @@ WHERE the_geom && GeomFromText('{0}', 4326)
 SELECT count(*)
 FROM linestringtest
 WHERE the_geom IS NOT NULL
-AND ST_Overlaps(PolygonFromText('{0}', 4326), the_geom)
+AND ST_Overlaps(ST_PolygonFromText('{0}', 4326), the_geom)
 ", filterString);
         }
 
@@ -55,7 +55,7 @@ AND ST_Overlaps(PolygonFromText('{0}', 4326), the_geom)
 SELECT count(*)
 FROM linestringtest
 WHERE the_geom IS NOT NULL
-AND ST_Intersects(PolygonFromText('{0}', 4326), the_geom)
+AND ST_Intersects(ST_PolygonFromText('{0}', 4326), the_geom)
 ", filterString);
         }
 

--- a/Tests.NHibernate.Spatial.PostGis/TestConfiguration.cs
+++ b/Tests.NHibernate.Spatial.PostGis/TestConfiguration.cs
@@ -14,7 +14,7 @@ namespace Tests.NHibernate.Spatial
         {
             IDictionary<string, string> properties = new Dictionary<string, string>();
             properties[Environment.ProxyFactoryFactoryClass] = typeof(NHibernateFactory).AssemblyQualifiedName;
-            properties[Environment.Dialect] = typeof(PostGisDialect).AssemblyQualifiedName;
+            properties[Environment.Dialect] = typeof(PostGis20Dialect).AssemblyQualifiedName;
             properties[Environment.ConnectionProvider] = typeof(DebugConnectionProvider).AssemblyQualifiedName;
             properties[Environment.ConnectionDriver] = typeof(NpgsqlDriver).AssemblyQualifiedName;
             properties[Environment.ConnectionString] = Settings.Default.ConnectionString;


### PR DESCRIPTION
ISO prefix was added to spatial functions in PostGIS 1.5 and the
non-prefixed ones deprecated. The non-prefixed ones were removed in
PostGIS 2.0.

Resolves issue: #32 