### PR TITLE
Add support for "SERIAL" type identity columns in PostGIS dialect

### DIFF
--- a/NHibernate.Spatial.PostGis/Dialect/PostGisDialect.cs
+++ b/NHibernate.Spatial.PostGis/Dialect/PostGisDialect.cs
@@ -46,26 +46,6 @@ namespace NHibernate.Spatial.Dialect
             RegisterFunctions();
         }
 
-        // TODO: Remove this property overrriding, it's meant to be temporary.
-        //
-        // "native"=>"serial" is not working with the current mappings.
-        // For PostresSQL 8.1+, this property is supposed to return true.
-        // But to make it work, now it returns false and maps "native"=>"sequence"
-        // An alternative is to use "sequence" in the mapping file directly,
-        // but, by using "native", I intend to keep the same mappings for all dialects.
-        //
-        /// <summary>
-        /// PostgreSQL supports Identity column using the "SERIAL" type.
-        /// </summary>
-        /// <value></value>
-        public override bool SupportsIdentityColumns
-        {
-            get
-            {
-                return false;
-            }
-        }
-
         public override string ToBooleanValueString(bool value)
         {
             return value ? "true" : "false";

--- a/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
+++ b/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
@@ -44,6 +44,10 @@
     <Reference Include="Iesi.Collections">
       <HintPath>..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
     </Reference>
+    <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.2.2.7\lib\net40\Mono.Security.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NetTopologySuite">
       <HintPath>..\packages\NetTopologySuite.1.13.3.2\lib\net40-client\NetTopologySuite.dll</HintPath>
     </Reference>
@@ -62,6 +66,10 @@
     <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="Npgsql, Version=2.2.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.2.2.7\lib\net40\Npgsql.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Tests.NHibernate.Spatial.PostGis/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis/packages.config
@@ -5,5 +5,6 @@
   <package id="NetTopologySuite" version="1.13.3.2" targetFramework="net40-Client" />
   <package id="NetTopologySuite.IO" version="1.13.3.2" targetFramework="net40-Client" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net40-Client" allowedVersions="[4,5)" />
+  <package id="Npgsql" version="2.2.7" targetFramework="net40-Client" />
   <package id="NUnit" version="2.6.4" targetFramework="net40-Client" />
 </packages>


### PR DESCRIPTION
Remove temporary override from 2009/2010 (see issue #23). Before after testing of change using PostgreSQL 9.4 x64 and PostGIS 2.1 resulted in no change in the number of passing (158/181) and failing (15/181) tests :)

Also adds Npgsql NuGet package to PostGIS tests project so that tests can run "out-of-the-box".
