### PR TITLE
Add support for nullable geometry columns in Oracle dialect schema export

### DIFF
--- a/NHibernate.Spatial.Oracle/Dialect/OracleSpatialDialect.cs
+++ b/NHibernate.Spatial.Oracle/Dialect/OracleSpatialDialect.cs
@@ -520,8 +520,9 @@ namespace NHibernate.Spatial.Dialect
         /// <param name="srid">The srid.</param>
         /// <param name="subtype">The subtype.</param>
         /// <param name="dimension">The dimension.</param>
+        /// <param name="isNullable">Whether or not the column is nullable.</param>
         /// <returns></returns>
-        public string GetSpatialCreateString(string schema, string table, string column, int srid, string subtype, int dimension)
+        public string GetSpatialCreateString(string schema, string table, string column, int srid, string subtype, int dimension, bool isNullable)
         {
             return null;
         }


### PR DESCRIPTION
Implement updated ISpatialDialect for Oracle dialect (see issue #26 and commit a72c6f5).

There are still many build errors for the Oracle project in general, but I don't have any experience with Oracle spatial databases so I don't think I'll be able to do too much more :/