### PR TITLE
Fix for geometry columns being generated as tinyints

### DIFF
--- a/NHibernate.Spatial.MySQL/Dialect/MySQLSpatialDialect.cs
+++ b/NHibernate.Spatial.MySQL/Dialect/MySQLSpatialDialect.cs
@@ -425,15 +425,15 @@ namespace NHibernate.Spatial.Dialect
 		/// <returns></returns>
 		public string GetSpatialCreateString(string schema)
 		{
-			return DoNothingQuery;
-		}
+            return null;
+        }
 
-		/// <summary>
-		/// Quotes the schema.
-		/// </summary>
-		/// <param name="schema">The schema.</param>
-		/// <returns></returns>
-		private string QuoteSchema(string schema)
+        /// <summary>
+        /// Quotes the schema.
+        /// </summary>
+        /// <param name="schema">The schema.</param>
+        /// <returns></returns>
+        private string QuoteSchema(string schema)
 		{
 			if (string.IsNullOrEmpty(schema))
 			{
@@ -489,19 +489,19 @@ namespace NHibernate.Spatial.Dialect
 		/// <returns></returns>
 		public string GetSpatialDropString(string schema)
 		{
-			return DoNothingQuery;
-		}
+            return null;
+        }
 
-		/// <summary>
-		/// Gets the spatial drop string.
-		/// </summary>
-		/// <param name="schema">The schema.</param>
-		/// <param name="table">The table.</param>
-		/// <param name="column">The column.</param>
-		/// <returns></returns>
-		public string GetSpatialDropString(string schema, string table, string column)
+        /// <summary>
+        /// Gets the spatial drop string.
+        /// </summary>
+        /// <param name="schema">The schema.</param>
+        /// <param name="table">The table.</param>
+        /// <param name="column">The column.</param>
+        /// <returns></returns>
+        public string GetSpatialDropString(string schema, string table, string column)
 		{
-			return DoNothingQuery;
+			return null;
 		}
 
 		/// <summary>
@@ -521,16 +521,6 @@ namespace NHibernate.Spatial.Dialect
 		public string MultipleQueriesSeparator
 		{
 			get { return ";"; }
-		}
-
-		/// <summary>
-		/// The MySQL dialect is the only dialect that does not need to create any "general" 
-		/// database objects when performing a schema export. Sadly, NHibernate chokes if
-		/// simply null or string.Empty is returned, and thus this DoNothingQuery was born.
-		/// </summary>
-		public string DoNothingQuery
-		{
-			get { return "SELECT 1"; }
 		}
 	}
 }

--- a/NHibernate.Spatial.MySQL/Type/MySQL57GeometryAdapterType.cs
+++ b/NHibernate.Spatial.MySQL/Type/MySQL57GeometryAdapterType.cs
@@ -71,7 +71,7 @@ namespace NHibernate.Spatial.Type
 
         public override System.Type ReturnedClass
         {
-            get { return typeof(MySQL57GeometryAdapterType); }
+            get { return typeof(MySqlGeometry); }
         }
 
         public override void Set(IDbCommand cmd, object value, int index)

--- a/NHibernate.Spatial/Mapping/SpatialAuxiliaryDatabaseObject.cs
+++ b/NHibernate.Spatial/Mapping/SpatialAuxiliaryDatabaseObject.cs
@@ -117,7 +117,9 @@ namespace NHibernate.Spatial.Mapping
                 Table table = persistentClass.Table;
                 foreach (Column column in table.ColumnIterator)
                 {
-                    if (column.Value.Type.ReturnedClass is IGeometry)
+                    if (column.Value.Type.ReturnedClass is IGeometry
+                        || (column.Value.Type.ReturnedClass.IsGenericType 
+                                && column.Value.Type.ReturnedClass.GetGenericTypeDefinition() == typeof(GeometryTypeBase<>)))
                     {
                         visitGeometryColumn(table, column);
                     }


### PR DESCRIPTION
After debugging the problem where using the schemaexporter produces tinyint columns for geometry columns for some dialects (postgis, mysql), I landed on this workaround which seems to do the job. The reason the MSSQL dialect works is because the Set() method in the SqlGeometryType class explicitly sets the UdtTypeName parameter on the SqlParameter. MSSQL however is the only client library which supports a field like this on its command parameters. This should fix issue #12.