### PR TITLE
Add iso prefix to spatial relation functions.

### DIFF
--- a/NHibernate.Spatial.MySQL/Dialect/MySQLSpatialDialect.cs
+++ b/NHibernate.Spatial.MySQL/Dialect/MySQLSpatialDialect.cs
@@ -311,7 +311,8 @@ namespace NHibernate.Spatial.Dialect
 
 				default:
 					return new SqlStringBuilder(6)
-						.Add(relation.ToString())
+                        .Add(SpatialDialect.IsoPrefix)
+                        .Add(relation.ToString())
 						.Add("(")
 						.AddObject(geometry)
 						.Add(", ")


### PR DESCRIPTION
This adds the iso prefix to spatial relation functions in the MySQL dialect, and fixes #58.