### PR TITLE
Added support for Npgsql 3.2.5+ and dropped support for 2.x

### DIFF
--- a/NHibernate.Spatial.PostGis/Dialect/PostGis20Dialect.cs
+++ b/NHibernate.Spatial.PostGis/Dialect/PostGis20Dialect.cs
@@ -65,12 +65,17 @@ namespace NHibernate.Spatial.Dialect
                 default:
                     throw new ArgumentException("Invalid spatial aggregate argument");
             }
-            return new SqlStringBuilder()
-                .Add(aggregateFunction)
+            var builder = new SqlStringBuilder();
+            builder.Add(aggregateFunction)
                 .Add("(")
                 .AddObject(geometry)
-                .Add(")")
-                .ToSqlString();
+                .Add(")");
+            // Convert to geometry as there is no binary output function available for type box2d type
+            if (aggregate == SpatialAggregate.Envelope)
+            {
+                builder.Add("::geometry");
+            }
+            return builder.ToSqlString();
         }
 
         /// <summary>

--- a/NHibernate.Spatial.PostGis/Dialect/PostGisDialect.cs
+++ b/NHibernate.Spatial.PostGis/Dialect/PostGisDialect.cs
@@ -270,12 +270,17 @@ namespace NHibernate.Spatial.Dialect
                 default:
                     throw new ArgumentException("Invalid spatial aggregate argument");
             }
-            return new SqlStringBuilder()
-                .Add(aggregateFunction)
+            var builder = new SqlStringBuilder();
+            builder.Add(aggregateFunction)
                 .Add("(")
                 .AddObject(geometry)
-                .Add(")")
-                .ToSqlString();
+                .Add(")");
+            // Convert to geometry as there is no binary output function available for type box2d type
+            if (aggregate == SpatialAggregate.Envelope)
+            {
+                builder.Add("::geometry");
+            }
+            return builder.ToSqlString();
         }
 
         public SqlString GetSpatialRelationString(object geometry, SpatialRelation relation, object anotherGeometry, bool criterion)

--- a/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
+++ b/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
@@ -70,6 +70,9 @@
     <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
       <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
     </Reference>
+    <Reference Include="Npgsql, Version=3.2.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.3.2.5\lib\net451\Npgsql.dll</HintPath>
+    </Reference>
     <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
@@ -84,6 +87,9 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/NHibernate.Spatial.PostGis/Type/PostGisGeometryType.cs
+++ b/NHibernate.Spatial.PostGis/Type/PostGisGeometryType.cs
@@ -94,7 +94,8 @@ namespace NHibernate.Spatial.Type
         /// <returns></returns>
         protected override IGeometry ToGeometry(object value)
         {
-            if (!(value is byte[] bytes))
+            var bytes = value as byte[];
+            if (bytes == null)
             {
                 return null;
             }

--- a/NHibernate.Spatial.PostGis/packages.config
+++ b/NHibernate.Spatial.PostGis/packages.config
@@ -6,6 +6,8 @@
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
   <package id="NetTopologySuite.IO" version="1.14.0.1" targetFramework="net461" />
   <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
+  <package id="Npgsql" version="3.2.5" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
+++ b/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
@@ -46,9 +46,6 @@
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
       <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
-      <HintPath>..\packages\Npgsql.2.2.7\lib\net45\Mono.Security.dll</HintPath>
-    </Reference>
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
@@ -58,8 +55,8 @@
     <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
       <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
     </Reference>
-    <Reference Include="Npgsql, Version=2.2.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7">
-      <HintPath>..\packages\Npgsql.2.2.7\lib\net45\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=3.2.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.3.2.5\lib\net451\Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -78,6 +75,9 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests.NHibernate.Spatial.PostGis/app.config
+++ b/Tests.NHibernate.Spatial.PostGis/app.config
@@ -6,7 +6,7 @@
   </configSections>
 
   <connectionStrings>
-    <add name="Tests.NHibernate.Spatial.Properties.Settings.ConnectionString" connectionString="Server=localhost;Port=5431;Database=nhsp_test;User Id=nhsp_test;Password=nhsp_test;Encoding=UNICODE;" />
+    <add name="Tests.NHibernate.Spatial.Properties.Settings.ConnectionString" connectionString="Server=localhost;Port=5431;Database=nhsp_test;User Id=nhsp_test;Password=nhsp_test;" />
   </connectionStrings>
 
   <log4net debug="true">

--- a/Tests.NHibernate.Spatial.PostGis/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis/packages.config
@@ -5,8 +5,9 @@
   <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
   <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
-  <package id="Npgsql" version="2.2.7" targetFramework="net461" />
+  <package id="Npgsql" version="3.2.5" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
+++ b/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
@@ -39,17 +39,14 @@
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
       <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
-      <HintPath>..\packages\Npgsql.2.2.7\lib\net45\Mono.Security.dll</HintPath>
-    </Reference>
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
     <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
       <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
     </Reference>
-    <Reference Include="Npgsql, Version=2.2.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7">
-      <HintPath>..\packages\Npgsql.2.2.7\lib\net45\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=3.2.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.3.2.5\lib\net451\Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -65,6 +62,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Tests.NHibernate.Spatial.PostGis20/app.config
+++ b/Tests.NHibernate.Spatial.PostGis20/app.config
@@ -6,7 +6,7 @@
   </configSections>
 
   <connectionStrings>
-    <add name="Tests.NHibernate.Spatial.Properties.Settings.ConnectionString" connectionString="Server=localhost;Port=5432;Database=nhsp_test;User Id=nhsp_test;Password=nhsp_test;Encoding=UNICODE;" />
+    <add name="Tests.NHibernate.Spatial.Properties.Settings.ConnectionString" connectionString="Server=localhost;Port=5432;Database=nhsp_test;User Id=nhsp_test;Password=nhsp_test;" />
   </connectionStrings>
 
   <log4net debug="true">

--- a/Tests.NHibernate.Spatial.PostGis20/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis20/packages.config
@@ -5,8 +5,9 @@
   <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
   <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
-  <package id="Npgsql" version="2.2.7" targetFramework="net461" />
+  <package id="Npgsql" version="3.2.5" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This PR contains the changes for the second approach from [this](https://github.com/nhibernate/NHibernate.Spatial/issues/31#issuecomment-370879109) comment. As already mentioned by @peetw, adding the `Npgsql` dependency to the `NHibernate.Spatial.PostGis` project shouldn't be a problem as it is the most popular driver and also the only driver that is supported by [`NHibernate`](https://github.com/nhibernate/nhibernate-core/blob/master/src/NHibernate/Driver/NpgsqlDriver.cs) for connecting to a `PostgreSQL` database. As most of the `NHibernate` users never use the `Npgsql` directly, dropping the support for `2.x` shouldn't be a problem. When the user will update to the new `NHibernate.Spatial.PostGis`, `Npgsql` will be automatically updated to the minimum supported version, which is `3.2.5`, so the process would be painless.