### PR TITLE
Update NuGet packages

### DIFF
--- a/NHibernate.Spatial.MsSql/NHibernate.Spatial.MsSql.csproj
+++ b/NHibernate.Spatial.MsSql/NHibernate.Spatial.MsSql.csproj
@@ -43,8 +43,9 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">
       <HintPath>..\packages\Microsoft.SqlServer.Types.11.0.2\lib\net20\Microsoft.SqlServer.Types.dll</HintPath>
@@ -52,8 +53,9 @@
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
@@ -65,10 +67,13 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/NHibernate.Spatial.MsSql/NHibernate.Spatial.MsSql.csproj
+++ b/NHibernate.Spatial.MsSql/NHibernate.Spatial.MsSql.csproj
@@ -40,8 +40,13 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
@@ -50,15 +55,17 @@
     <Reference Include="Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">
       <HintPath>..\packages\Microsoft.SqlServer.Types.11.0.2\lib\net20\Microsoft.SqlServer.Types.dll</HintPath>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/NHibernate.Spatial.MsSql/packages.config
+++ b/NHibernate.Spatial.MsSql/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net461" developmentDependency="true" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/NHibernate.Spatial.MsSql/packages.config
+++ b/NHibernate.Spatial.MsSql/packages.config
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net461" developmentDependency="true" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/NHibernate.Spatial.MySQL/NHibernate.Spatial.MySQL.csproj
+++ b/NHibernate.Spatial.MySQL/NHibernate.Spatial.MySQL.csproj
@@ -40,8 +40,13 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
@@ -50,15 +55,17 @@
     <Reference Include="MySql.Data, Version=6.9.10.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
       <HintPath>..\packages\MySql.Data.6.9.10\lib\net45\MySql.Data.dll</HintPath>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/NHibernate.Spatial.MySQL/NHibernate.Spatial.MySQL.csproj
+++ b/NHibernate.Spatial.MySQL/NHibernate.Spatial.MySQL.csproj
@@ -52,8 +52,10 @@
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MySql.Data, Version=6.9.10.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
-      <HintPath>..\packages\MySql.Data.6.9.10\lib\net45\MySql.Data.dll</HintPath>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="MySql.Data, Version=6.10.7.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySql.Data.6.10.7\lib\net452\MySql.Data.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
       <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
@@ -74,11 +76,17 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Drawing.Design" />
+    <Reference Include="System.Management" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
@@ -104,7 +112,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/NHibernate.Spatial.MySQL/NHibernate.Spatial.MySQL.csproj
+++ b/NHibernate.Spatial.MySQL/NHibernate.Spatial.MySQL.csproj
@@ -43,8 +43,9 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MySql.Data, Version=6.9.10.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
       <HintPath>..\packages\MySql.Data.6.9.10\lib\net45\MySql.Data.dll</HintPath>
@@ -52,8 +53,9 @@
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
@@ -65,10 +67,13 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/NHibernate.Spatial.MySQL/app.config
+++ b/NHibernate.Spatial.MySQL/app.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <system.data>
-    <DbProviderFactories>
-      <remove invariant="MySql.Data.MySqlClient" />
-      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.10.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
-    </DbProviderFactories>
-  </system.data>
-</configuration>

--- a/NHibernate.Spatial.MySQL/packages.config
+++ b/NHibernate.Spatial.MySQL/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="MySql.Data" version="6.9.10" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/NHibernate.Spatial.MySQL/packages.config
+++ b/NHibernate.Spatial.MySQL/packages.config
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="MySql.Data" version="6.9.10" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/NHibernate.Spatial.MySQL/packages.config
+++ b/NHibernate.Spatial.MySQL/packages.config
@@ -4,7 +4,7 @@
   <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
   <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
-  <package id="MySql.Data" version="6.9.10" targetFramework="net461" />
+  <package id="MySql.Data" version="6.10.7" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
   <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
   <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />

--- a/NHibernate.Spatial.Oracle/MGeometries/MCoordinateSequence.cs
+++ b/NHibernate.Spatial.Oracle/MGeometries/MCoordinateSequence.cs
@@ -232,12 +232,16 @@ namespace NHibernate.Spatial.MGeometries
 
         public Object Clone()
         {
-            MCoordinate[] cloneCoordinates = new MCoordinate[Count];
+            return Copy();
+        }
+
+        public ICoordinateSequence Copy()
+        {
+            var cloneCoordinates = new MCoordinate[coordinates.Length];
             for (int i = 0; i < coordinates.Length; i++)
             {
-                cloneCoordinates[i] = (MCoordinate)coordinates[i].Clone();
+                cloneCoordinates[i] = (MCoordinate) coordinates[i].Copy();
             }
-
             return new MCoordinateSequence(cloneCoordinates);
         }
 

--- a/NHibernate.Spatial.Oracle/NHibernate.Spatial.Oracle.csproj
+++ b/NHibernate.Spatial.Oracle/NHibernate.Spatial.Oracle.csproj
@@ -59,14 +59,16 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Oracle.DataAccess, Version=4.112.3.0, Culture=neutral, PublicKeyToken=89b483f429c47342, processorArchitecture=x86">
       <HintPath>..\packages\odp.net.x86.112.3.20\lib\net40\Oracle.DataAccess.dll</HintPath>
@@ -82,11 +84,14 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <HintPath>..\..\..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\Profile\Client\System.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Data.OracleClient" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/NHibernate.Spatial.Oracle/NHibernate.Spatial.Oracle.csproj
+++ b/NHibernate.Spatial.Oracle/NHibernate.Spatial.Oracle.csproj
@@ -56,15 +56,25 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
@@ -73,9 +83,6 @@
     <Reference Include="Oracle.DataAccess, Version=4.112.3.0, Culture=neutral, PublicKeyToken=89b483f429c47342, processorArchitecture=x86">
       <HintPath>..\packages\odp.net.x86.112.3.20\lib\net40\Oracle.DataAccess.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/NHibernate.Spatial.Oracle/packages.config
+++ b/NHibernate.Spatial.Oracle/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" />
   <package id="odp.net.x64" version="112.3.20" targetFramework="net461" />
   <package id="odp.net.x86" version="112.3.20" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />

--- a/NHibernate.Spatial.Oracle/packages.config
+++ b/NHibernate.Spatial.Oracle/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" />
   <package id="odp.net.x64" version="112.3.20" targetFramework="net461" />
   <package id="odp.net.x86" version="112.3.20" targetFramework="net461" />

--- a/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
+++ b/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
@@ -72,8 +72,9 @@
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Npgsql, Version=3.2.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Npgsql.3.2.5\lib\net451\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=3.2.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.3.2.7\lib\net451\Npgsql.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>

--- a/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
+++ b/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
@@ -43,8 +43,9 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
@@ -67,8 +68,9 @@
     <Reference Include="NetTopologySuite.IO.ShapeFile.Extended, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\NetTopologySuite.IO.1.14.0.1\lib\net45\NetTopologySuite.IO.ShapeFile.Extended.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Npgsql, Version=3.2.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.2.5\lib\net451\Npgsql.dll</HintPath>
@@ -83,13 +85,16 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
+++ b/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
@@ -40,33 +40,29 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite.IO, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.IO.1.14.0.1\lib\net45\NetTopologySuite.IO.dll</HintPath>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite.IO.GeoTools, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.IO.1.14.0.1\lib\net45\NetTopologySuite.IO.GeoTools.dll</HintPath>
-    </Reference>
-    <Reference Include="NetTopologySuite.IO.MsSqlSpatial, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.IO.1.14.0.1\lib\net45\NetTopologySuite.IO.MsSqlSpatial.dll</HintPath>
-    </Reference>
-    <Reference Include="NetTopologySuite.IO.PostGis, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.IO.1.14.0.1\lib\net45\NetTopologySuite.IO.PostGis.dll</HintPath>
-    </Reference>
-    <Reference Include="NetTopologySuite.IO.ShapeFile, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.IO.1.14.0.1\lib\net45\NetTopologySuite.IO.ShapeFile.dll</HintPath>
-    </Reference>
-    <Reference Include="NetTopologySuite.IO.ShapeFile.Extended, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\NetTopologySuite.IO.1.14.0.1\lib\net45\NetTopologySuite.IO.ShapeFile.Extended.dll</HintPath>
+    <Reference Include="NetTopologySuite.IO.PostGis, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.IO.PostGis.1.15.0\lib\net45\NetTopologySuite.IO.PostGis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
@@ -75,9 +71,6 @@
     <Reference Include="Npgsql, Version=3.2.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.2.7\lib\net451\Npgsql.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/NHibernate.Spatial.PostGis/packages.config
+++ b/NHibernate.Spatial.PostGis/packages.config
@@ -6,7 +6,7 @@
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
   <package id="NetTopologySuite.IO" version="1.14.0.1" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
-  <package id="Npgsql" version="3.2.5" targetFramework="net461" />
+  <package id="Npgsql" version="3.2.7" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />

--- a/NHibernate.Spatial.PostGis/packages.config
+++ b/NHibernate.Spatial.PostGis/packages.config
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NetTopologySuite.IO" version="1.14.0.1" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.IO.PostGis" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Npgsql" version="3.2.7" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />

--- a/NHibernate.Spatial.PostGis/packages.config
+++ b/NHibernate.Spatial.PostGis/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
   <package id="NetTopologySuite.IO" version="1.14.0.1" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Npgsql" version="3.2.5" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/NHibernate.Spatial/NHibernate.Spatial.csproj
+++ b/NHibernate.Spatial/NHibernate.Spatial.csproj
@@ -54,14 +54,16 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
@@ -73,10 +75,13 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/NHibernate.Spatial/NHibernate.Spatial.csproj
+++ b/NHibernate.Spatial/NHibernate.Spatial.csproj
@@ -51,22 +51,29 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/NHibernate.Spatial/packages.config
+++ b/NHibernate.Spatial/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/NHibernate.Spatial/packages.config
+++ b/NHibernate.Spatial/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/NetTopologySuite.TestRunner/Functions/ConstructionFunctions.cs
+++ b/NetTopologySuite.TestRunner/Functions/ConstructionFunctions.cs
@@ -4,7 +4,6 @@ using NetTopologySuite.Densify;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Utilities;
 using NetTopologySuite.Operation.Linemerge;
-using System.Collections;
 
 namespace Open.Topology.TestRunner.Functions
 {
@@ -67,7 +66,7 @@ namespace Open.Topology.TestRunner.Functions
         public static IGeometry extractLines(IGeometry g)
         {
             var lines = LinearComponentExtracter.GetLines(g);
-            return g.Factory.BuildGeometry(NetTopologySuite.Utilities.CollectionUtil.Cast<IGeometry>((ICollection)lines));
+            return g.Factory.BuildGeometry(lines);
         }
     }
 }

--- a/NetTopologySuite.TestRunner/Functions/NodingFunctions.cs
+++ b/NetTopologySuite.TestRunner/Functions/NodingFunctions.cs
@@ -2,9 +2,8 @@
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Noding.Snapround;
 using NetTopologySuite.Precision;
-using NetTopologySuite.Utilities;
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Open.Topology.TestRunner.Functions
 {
@@ -22,7 +21,7 @@ namespace Open.Topology.TestRunner.Functions
             var noder = new GeometryNoder(pm);
             var lines = noder.Node(geomList);
 
-            return Utility.FunctionsUtil.getFactoryOrDefault(geom).BuildGeometry(CollectionUtil.Cast<IGeometry>((ICollection)lines));
+            return Utility.FunctionsUtil.getFactoryOrDefault(geom).BuildGeometry(lines.Cast<IGeometry>().ToList());
         }
     }
 }

--- a/NetTopologySuite.TestRunner/NetTopologySuite.TestRunner.csproj
+++ b/NetTopologySuite.TestRunner/NetTopologySuite.TestRunner.csproj
@@ -99,16 +99,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net35-client\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net35-client\GeoAPI.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net35-client\NetTopologySuite.dll</HintPath>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net35-client\GeoAPI.CoordinateSystems.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5, processorArchitecture=MSIL">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net35-client\PowerCollections.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net35-client\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net35-client\NetTopologySuite.CoordinateSystems.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System">
@@ -221,9 +225,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/NetTopologySuite.TestRunner/packages.config
+++ b/NetTopologySuite.TestRunner/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GeoAPI" version="1.7.4" targetFramework="net35-client" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net35-client" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net35-client" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net35-client" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net35-client" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net35-client" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net35-client" />
 </packages>

--- a/Tests.NHibernate.Spatial.MsSql2008/Tests.NHibernate.Spatial.MsSql2008.csproj
+++ b/Tests.NHibernate.Spatial.MsSql2008/Tests.NHibernate.Spatial.MsSql2008.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,6 +19,8 @@
     <UpgradeBackupLocation />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -67,8 +70,9 @@
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
@@ -129,6 +133,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests.NHibernate.Spatial.MsSql2008/Tests.NHibernate.Spatial.MsSql2008.csproj
+++ b/Tests.NHibernate.Spatial.MsSql2008/Tests.NHibernate.Spatial.MsSql2008.csproj
@@ -43,8 +43,9 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
@@ -52,8 +53,9 @@
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -68,10 +70,13 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests.NHibernate.Spatial.MsSql2008/Tests.NHibernate.Spatial.MsSql2008.csproj
+++ b/Tests.NHibernate.Spatial.MsSql2008/Tests.NHibernate.Spatial.MsSql2008.csproj
@@ -40,8 +40,13 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
@@ -50,8 +55,13 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
@@ -59,9 +69,6 @@
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/Tests.NHibernate.Spatial.MsSql2008/packages.config
+++ b/Tests.NHibernate.Spatial.MsSql2008/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.MsSql2008/packages.config
+++ b/Tests.NHibernate.Spatial.MsSql2008/packages.config
@@ -9,7 +9,7 @@
   <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
   <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/Tests.NHibernate.Spatial.MsSql2008/packages.config
+++ b/Tests.NHibernate.Spatial.MsSql2008/packages.config
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.MsSql2012/Tests.NHibernate.Spatial.MsSql2012.csproj
+++ b/Tests.NHibernate.Spatial.MsSql2012/Tests.NHibernate.Spatial.MsSql2012.csproj
@@ -43,8 +43,9 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
@@ -52,8 +53,9 @@
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -68,10 +70,13 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests.NHibernate.Spatial.MsSql2012/Tests.NHibernate.Spatial.MsSql2012.csproj
+++ b/Tests.NHibernate.Spatial.MsSql2012/Tests.NHibernate.Spatial.MsSql2012.csproj
@@ -40,8 +40,13 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
@@ -50,8 +55,13 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
@@ -59,9 +69,6 @@
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/Tests.NHibernate.Spatial.MsSql2012/Tests.NHibernate.Spatial.MsSql2012.csproj
+++ b/Tests.NHibernate.Spatial.MsSql2012/Tests.NHibernate.Spatial.MsSql2012.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,6 +19,8 @@
     <UpgradeBackupLocation />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -67,8 +70,9 @@
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
@@ -133,6 +137,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests.NHibernate.Spatial.MsSql2012/packages.config
+++ b/Tests.NHibernate.Spatial.MsSql2012/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.MsSql2012/packages.config
+++ b/Tests.NHibernate.Spatial.MsSql2012/packages.config
@@ -9,7 +9,7 @@
   <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
   <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/Tests.NHibernate.Spatial.MsSql2012/packages.config
+++ b/Tests.NHibernate.Spatial.MsSql2012/packages.config
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.MySQL/Tests.NHibernate.Spatial.MySQL.csproj
+++ b/Tests.NHibernate.Spatial.MySQL/Tests.NHibernate.Spatial.MySQL.csproj
@@ -43,14 +43,16 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -65,10 +67,13 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests.NHibernate.Spatial.MySQL/Tests.NHibernate.Spatial.MySQL.csproj
+++ b/Tests.NHibernate.Spatial.MySQL/Tests.NHibernate.Spatial.MySQL.csproj
@@ -40,15 +40,25 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
@@ -56,9 +66,6 @@
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/Tests.NHibernate.Spatial.MySQL/Tests.NHibernate.Spatial.MySQL.csproj
+++ b/Tests.NHibernate.Spatial.MySQL/Tests.NHibernate.Spatial.MySQL.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,6 +19,8 @@
     <UpgradeBackupLocation />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -64,8 +67,9 @@
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
@@ -121,6 +125,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests.NHibernate.Spatial.MySQL/packages.config
+++ b/Tests.NHibernate.Spatial.MySQL/packages.config
@@ -8,7 +8,7 @@
   <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
   <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" />
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/Tests.NHibernate.Spatial.MySQL/packages.config
+++ b/Tests.NHibernate.Spatial.MySQL/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.MySQL/packages.config
+++ b/Tests.NHibernate.Spatial.MySQL/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.MySQL57/Tests.NHibernate.Spatial.MySQL57.csproj
+++ b/Tests.NHibernate.Spatial.MySQL57/Tests.NHibernate.Spatial.MySQL57.csproj
@@ -33,15 +33,25 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
@@ -49,9 +59,6 @@
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/Tests.NHibernate.Spatial.MySQL57/Tests.NHibernate.Spatial.MySQL57.csproj
+++ b/Tests.NHibernate.Spatial.MySQL57/Tests.NHibernate.Spatial.MySQL57.csproj
@@ -36,14 +36,16 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -58,7 +60,10 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Tests.NHibernate.Spatial.MySQL57/Tests.NHibernate.Spatial.MySQL57.csproj
+++ b/Tests.NHibernate.Spatial.MySQL57/Tests.NHibernate.Spatial.MySQL57.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>Tests.NHibernate.Spatial.MySQL57</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -57,8 +60,9 @@
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
@@ -120,6 +124,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests.NHibernate.Spatial.MySQL57/packages.config
+++ b/Tests.NHibernate.Spatial.MySQL57/packages.config
@@ -8,7 +8,7 @@
   <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
   <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" />
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/Tests.NHibernate.Spatial.MySQL57/packages.config
+++ b/Tests.NHibernate.Spatial.MySQL57/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.MySQL57/packages.config
+++ b/Tests.NHibernate.Spatial.MySQL57/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
+++ b/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,6 +19,8 @@
     <UpgradeBackupLocation />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -68,8 +71,9 @@
       <HintPath>..\packages\Npgsql.3.2.7\lib\net451\Npgsql.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
@@ -132,6 +136,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
+++ b/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
@@ -57,8 +57,9 @@
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Npgsql, Version=3.2.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Npgsql.3.2.5\lib\net451\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=3.2.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.3.2.7\lib\net451\Npgsql.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
+++ b/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
@@ -40,18 +40,25 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
@@ -63,9 +70,6 @@
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
+++ b/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
@@ -43,8 +43,9 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
@@ -52,8 +53,9 @@
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Npgsql, Version=3.2.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.2.5\lib\net451\Npgsql.dll</HintPath>
@@ -71,13 +73,16 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests.NHibernate.Spatial.PostGis/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis/packages.config
@@ -9,7 +9,7 @@
   <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Npgsql" version="3.2.7" targetFramework="net461" />
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.PostGis/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Npgsql" version="3.2.7" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.PostGis/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis/packages.config
@@ -5,7 +5,7 @@
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
-  <package id="Npgsql" version="3.2.5" targetFramework="net461" />
+  <package id="Npgsql" version="3.2.7" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.PostGis/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Npgsql" version="3.2.5" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
+++ b/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
@@ -47,8 +47,9 @@
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Npgsql, Version=3.2.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Npgsql.3.2.5\lib\net451\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=3.2.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.3.2.7\lib\net451\Npgsql.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
+++ b/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>Tests.NHibernate.Spatial.PostGis20</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,8 +64,9 @@
       <HintPath>..\packages\Npgsql.3.2.7\lib\net451\Npgsql.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
@@ -125,6 +129,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
+++ b/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
@@ -33,15 +33,25 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
@@ -53,9 +63,6 @@
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
+++ b/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
@@ -36,14 +36,16 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Npgsql, Version=3.2.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.2.5\lib\net451\Npgsql.dll</HintPath>
@@ -61,10 +63,13 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Tests.NHibernate.Spatial.PostGis20/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis20/packages.config
@@ -9,7 +9,7 @@
   <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Npgsql" version="3.2.7" targetFramework="net461" />
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.PostGis20/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis20/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Npgsql" version="3.2.7" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.PostGis20/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis20/packages.config
@@ -5,7 +5,7 @@
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
-  <package id="Npgsql" version="3.2.5" targetFramework="net461" />
+  <package id="Npgsql" version="3.2.7" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial.PostGis20/packages.config
+++ b/Tests.NHibernate.Spatial.PostGis20/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" allowedVersions="[5,6)" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" allowedVersions="[5,6)" />
   <package id="Npgsql" version="3.2.5" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial/AbstractFixture.cs
+++ b/Tests.NHibernate.Spatial/AbstractFixture.cs
@@ -41,7 +41,7 @@ namespace Tests.NHibernate.Spatial
         /// <summary>
         /// Creates the tables used in this TestCase
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
             try
@@ -108,7 +108,7 @@ namespace Tests.NHibernate.Spatial
         /// will occur if the TestCase does not have the same hbm.xml files
         /// included as a previous one.
         /// </remarks>
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
             OnTestFixtureTearDown();

--- a/Tests.NHibernate.Spatial/CriteriaFixture.cs
+++ b/Tests.NHibernate.Spatial/CriteriaFixture.cs
@@ -160,13 +160,19 @@ namespace Tests.NHibernate.Spatial
 		}
 
 		[Test]
-		[ExpectedException(typeof(MappingException))]
 		public void CountEmpty()
 		{
-			IList results = _session.CreateCriteria(typeof(Simple))
-				.Add(Restrictions.IsEmpty("Geometry"))
-				.List();
-			Assert.AreEqual(0, results.Count);
+		    try
+		    {
+		        IList results = _session.CreateCriteria(typeof(Simple))
+		            .Add(Restrictions.IsEmpty("Geometry"))
+		            .List();
+		        Assert.AreEqual(0, results.Count);
+		    }
+		    catch (MappingException)
+		    {
+		        // Ignored
+		    }
 		}
 
 		[Test]

--- a/Tests.NHibernate.Spatial/Tests.NHibernate.Spatial.csproj
+++ b/Tests.NHibernate.Spatial/Tests.NHibernate.Spatial.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -26,6 +27,8 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -75,8 +78,9 @@
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
@@ -190,6 +194,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests.NHibernate.Spatial/Tests.NHibernate.Spatial.csproj
+++ b/Tests.NHibernate.Spatial/Tests.NHibernate.Spatial.csproj
@@ -48,8 +48,13 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
-      <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
+    <Reference Include="GeoAPI, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.Core.1.7.5\lib\net45\GeoAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="GeoAPI.CoordinateSystems, Version=1.7.5.0, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoAPI.CoordinateSystems.1.7.5\lib\net45\GeoAPI.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
@@ -58,8 +63,13 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
+    <Reference Include="NetTopologySuite, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.Core.1.15.0\lib\net45\NetTopologySuite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetTopologySuite.CoordinateSystems, Version=1.15.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetTopologySuite.CoordinateSystems.1.15.0\lib\net45\NetTopologySuite.CoordinateSystems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
@@ -67,9 +77,6 @@
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5">
-      <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\PowerCollections.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b">
       <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>

--- a/Tests.NHibernate.Spatial/Tests.NHibernate.Spatial.csproj
+++ b/Tests.NHibernate.Spatial/Tests.NHibernate.Spatial.csproj
@@ -51,8 +51,9 @@
     <Reference Include="GeoAPI, Version=1.7.4.0, Culture=neutral, PublicKeyToken=a1a0da7def465678">
       <HintPath>..\packages\GeoAPI.1.7.4\lib\net45\GeoAPI.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
@@ -60,8 +61,9 @@
     <Reference Include="NetTopologySuite, Version=1.14.0.0, Culture=neutral, PublicKeyToken=f580a05016ebada1">
       <HintPath>..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.1.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.1.3\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -76,10 +78,13 @@
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests.NHibernate.Spatial/packages.config
+++ b/Tests.NHibernate.Spatial/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.0" targetFramework="net461" />
+  <package id="NHibernate" version="5.1.3" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/Tests.NHibernate.Spatial/packages.config
+++ b/Tests.NHibernate.Spatial/packages.config
@@ -9,7 +9,7 @@
   <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
   <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" />
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/Tests.NHibernate.Spatial/packages.config
+++ b/Tests.NHibernate.Spatial/packages.config
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="GeoAPI" version="1.7.4" targetFramework="net461" />
+  <package id="GeoAPI.CoordinateSystems" version="1.7.5" targetFramework="net461" />
+  <package id="GeoAPI.Core" version="1.7.5" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
-  <package id="NetTopologySuite" version="1.14" targetFramework="net461" />
+  <package id="NetTopologySuite" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.CoordinateSystems" version="1.15.0" targetFramework="net461" />
+  <package id="NetTopologySuite.Core" version="1.15.0" targetFramework="net461" />
   <package id="NHibernate" version="5.1.3" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />


### PR DESCRIPTION
Update NuGet packages to versions that support .NET Standard (required as part of #96). All packages now support .NET Standard, apart from `Microsoft.SqlServer.Types` and `odp.net.*`.

Note that the following packages haven't been updated to the very latest versions:

| Package | Reason |
| --- | --- |
| `Remotion.*` | Would require binding redirects for no benefit |
| `System.Threading.Tasks.Extensions` | As above |
| `Npgsql` | Too many unknowns moving from v3 -> v4 |
| `MySql.Data` | Waiting for 8.0.13 which contains `MySqlGeometry` [bug fix](https://bugs.mysql.com/bug.php?id=86974)  |

Closes #95 