### PR TITLE
Fix for saving/loading large geometries using MsSql

### DIFF
--- a/NHibernate.Spatial.MsSql/Type/MsSqlGeometryType.cs
+++ b/NHibernate.Spatial.MsSql/Type/MsSqlGeometryType.cs
@@ -63,7 +63,8 @@ namespace NHibernate.Spatial.Type
             public override void Set(DbCommand cmd, object value, int index, ISessionImplementor session)
             {
                 var parameter = (SqlParameter) cmd.Parameters[index];
-                parameter.SqlDbType = SqlDbType.Binary;
+                parameter.SqlDbType = SqlDbType.VarBinary;
+                parameter.Size = ((byte[])value).Length;
                 parameter.Value = value;
             }
 

--- a/NHibernate.Spatial.props
+++ b/NHibernate.Spatial.props
@@ -6,7 +6,7 @@
     <VersionMinor Condition="'$(VersionMinor)' == ''">2</VersionMinor>
     <VersionPatch Condition="'$(VersionPatch)' == ''">1</VersionPatch>
     <!-- NOTE: Set to "preXYZ" for pre-releases and leave blank for full releases -->
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">pre001</VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == ''">pre002</VersionSuffix>
 
     <!-- NOTE: Generally shouldn't need to edit anything below this line -->
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>


### PR DESCRIPTION
Fixes #114 for large geometries that are above the SqlDbType.Binary 8000 byte limit.