### PR TITLE
Use Npgsql's PostGIS/NTS plug-in for Geometry type

### DIFF
--- a/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
+++ b/NHibernate.Spatial.PostGis/NHibernate.Spatial.PostGis.csproj
@@ -28,8 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetTopologySuite.IO.PostGis" Version="2.0.0" />
-    <PackageReference Include="Npgsql" Version="[3.2.7, 4.0)" />
+    <PackageReference Include="NetTopologySuite.IO.PostGis" Version="2.1.0" />
+    <PackageReference Include="Npgsql" Version="4.1.0" />
+    <PackageReference Include="Npgsql.NetTopologySuite" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NHibernate.Spatial.PostGis/Type/PostGisGeometryType.cs
+++ b/NHibernate.Spatial.PostGis/Type/PostGisGeometryType.cs
@@ -16,7 +16,6 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 using NetTopologySuite.Geometries;
-using NetTopologySuite.IO;
 using System;
 using System.Data.Common;
 using NHibernate.Engine;
@@ -28,7 +27,7 @@ using NpgsqlTypes;
 namespace NHibernate.Spatial.Type
 {
     [Serializable]
-    public class PostGisGeometryType : GeometryTypeBase<byte[]>
+    public class PostGisGeometryType : GeometryTypeBase<Geometry>
     {
         private static readonly NullableType GeometryType = new CustomGeometryType();
 
@@ -45,45 +44,17 @@ namespace NHibernate.Spatial.Type
         /// </summary>
         /// <param name="value">The GeoAPI geometry value.</param>
         /// <returns></returns>
-        protected override byte[] FromGeometry(object value)
+        protected override Geometry FromGeometry(object value)
         {
-            Geometry geometry = value as Geometry;
+            var geometry = value as Geometry;
             if (geometry == null)
             {
                 return null;
             }
-            // PostGIS can't parse a WKB of any empty geometry other than GeomtryCollection
-            // (throws the error: "geometry requires more points")
-            // and parses WKT of empty geometries always as GeometryCollection
-            // (ie. "select AsText(GeomFromText('LINESTRING EMPTY', -1)) = 'GEOMETRYCOLLECTION EMPTY'").
-            // Force GeometryCollection.Empty to avoid the error.
-            if (!(geometry is GeometryCollection) && geometry.IsEmpty)
-            {
-                geometry = GeometryCollection.Empty;
-            }
 
             this.SetDefaultSRID(geometry);
 
-            // Determine the ordinality of the geometry to ensure 3D and 4D geometries are
-            // correctly serialized by PostGisWriter (see issue #66)
-            // NOTE: Cannot use InteriorPoint here as that always returns a 2D point (see #120)
-            // TODO: Is there a way of getting the ordinates directly from the geometry?
-            var ordinates = Ordinates.XY;
-            var coordinate = geometry.Coordinate;
-            if (coordinate != null && !double.IsNaN(coordinate.Z))
-            {
-                ordinates |= Ordinates.Z;
-            }
-            if (coordinate != null && !double.IsNaN(coordinate.M))
-            {
-                ordinates |= Ordinates.M;
-            }
-
-            var postGisWriter = new PostGisWriter
-            {
-                HandleOrdinates = ordinates
-            };
-            return postGisWriter.Write(geometry);
+            return geometry;
         }
 
         /// <summary>
@@ -93,15 +64,14 @@ namespace NHibernate.Spatial.Type
         /// <returns></returns>
         protected override Geometry ToGeometry(object value)
         {
-            var bytes = value as byte[];
-            if (bytes == null)
+            var geometry = value as Geometry;
+            if (geometry == null)
             {
                 return null;
             }
 
-            PostGisReader reader = new PostGisReader();
-            Geometry geometry = reader.Read(bytes);
             this.SetDefaultSRID(geometry);
+
             return geometry;
         }
 
@@ -114,16 +84,7 @@ namespace NHibernate.Spatial.Type
 
             public override object Get(DbDataReader rs, int index, ISessionImplementor session)
             {
-                // Npgsql 3 from the received bytes creates his own PostGisGeometry type.
-                // As we need to return a byte array that represents the geometry object,
-                // we will retrive the bytes from the reader instead.
-                var length = (int)rs.GetBytes(index, 0, null, 0, 0);
-                var buffer = new byte[length];
-                if (length > 0)
-                {
-                    rs.GetBytes(index, 0, buffer, 0, length);
-                }
-                return buffer;
+                return (Geometry)rs.GetValue(index);
             }
 
             public override object Get(DbDataReader rs, string name, ISessionImplementor session)
@@ -144,8 +105,8 @@ namespace NHibernate.Spatial.Type
 
             public override object DeepCopyNotNull(object value)
             {
-                var arr = (byte[]) value;
-                return arr.Clone();
+                var obj = (Geometry)value;
+                return obj.Copy();
             }
         }
     }

--- a/NetTopologySuite.TestRunner/NetTopologySuite.TestRunner.csproj
+++ b/NetTopologySuite.TestRunner/NetTopologySuite.TestRunner.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetTopologySuite" Version="2.1.0" />
+    <PackageReference Include="NetTopologySuite" Version="2.5.0" />
   </ItemGroup>
 
 </Project>

--- a/NetTopologySuite.TestRunner/Utility/WKTOrWKBReader.cs
+++ b/NetTopologySuite.TestRunner/Utility/WKTOrWKBReader.cs
@@ -42,7 +42,7 @@ namespace Open.Topology.TestRunner.Utility
 
         public WKTOrWKBReader(GeometryFactory geomFactory)
         {
-            _wktReader = new WKTReader(geomFactory);
+            _wktReader = new WKTReader(geomFactory) {  IsOldNtsCoordinateSyntaxAllowed = false };
 #pragma warning disable 612
             _wkbReader = new WKBReader();
 #pragma warning restore 612

--- a/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
+++ b/Tests.NHibernate.Spatial.PostGis/Tests.NHibernate.Spatial.PostGis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Tests.NHibernate.Spatial.PostGis20/TestConfiguration.cs
+++ b/Tests.NHibernate.Spatial.PostGis20/TestConfiguration.cs
@@ -3,6 +3,7 @@ using NHibernate.Bytecode;
 using NHibernate.Cfg;
 using NHibernate.Driver;
 using NHibernate.Spatial.Dialect;
+using Npgsql;
 using System.Collections.Generic;
 
 namespace Tests.NHibernate.Spatial
@@ -29,6 +30,7 @@ namespace Tests.NHibernate.Spatial
                 [Environment.ConnectionString] = _configurationRoot.GetConnectionString("PostGis20")
             };
             configuration.SetProperties(properties);
+            NpgsqlConnection.GlobalTypeMapper.UseNetTopologySuite();
         }
     }
 }

--- a/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
+++ b/Tests.NHibernate.Spatial.PostGis20/Tests.NHibernate.Spatial.PostGis20.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Tests.NHibernate.Spatial/AbstractFixture.cs
+++ b/Tests.NHibernate.Spatial/AbstractFixture.cs
@@ -24,7 +24,7 @@ namespace Tests.NHibernate.Spatial
     public abstract class AbstractFixture
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(AbstractFixture));
-        protected static readonly WKTReader Wkt = new WKTReader();
+        protected static readonly WKTReader Wkt = new WKTReader() { IsOldNtsCoordinateSyntaxAllowed = false };
         protected Configuration configuration;
         protected ISessionFactory sessions;
         private ISpatialDialect spatialDialect;


### PR DESCRIPTION
This adds support for Npgsql 4.1.0+, fixing #123 and #125. Npgsql 4.1.0+ uses its own NTS plug-in to support the Geometry type, bypassing the need for NHibernate.Spatial to do any conversions. I'm not really familiar with NHibernate's custom type mappings, so a review of that would be appreciated, but this does pass all of the PostGis20 tests. For example, I did remove some validation code from the PostGisGeometryType assuming they were covered by the tests and now handled by the plug-in, but did not verify. I ran the tests with the latest 4.1, 5.0, and 6.0 versions of Npgsql. I have not yet used this in a production project.

Due to some library changes, a couple of things may be required for users that want to use this:

1) Enable Npgsql's NTS plug-in for your connections: `NpgsqlConnection.GlobalTypeMapper.UseNetTopologySuite();` globally or `conn.TypeMapper.UseNetTopologySuite();` individually
2) If you otherwise use NTS.IO in your project and upgrade to these newer bits, you will likely need to add `IsOldNtsCoordinateSyntaxAllowed = false` to your WKTReaders to prevent Z coordinates from defaulting to NaN on 2D WKTs and throwing errors when inserting/updating